### PR TITLE
fixed authentification routes

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,13 +2,11 @@ import React from 'react';
 import logo from './logo.svg';
 import './App.css';
 import { Link } from 'react-router-dom';
-import AppProvider from './AppProvider';
 
 class App extends React.Component{
 
   render(){
     return (
-      <AppProvider>
         <nav>
           <Link to="/AuthContent1">Go To Auth Content 1</Link>
           <br/>
@@ -18,7 +16,6 @@ class App extends React.Component{
           <br/>
           <Link to="/OpenContent2">Go To Open Content 2</Link>
         </nav>
-      </AppProvider>
     );
   }
 }

--- a/src/AppProvider.js
+++ b/src/AppProvider.js
@@ -1,10 +1,11 @@
 import AppContext from './AppContext';
 import React from 'react';
+import fakeAuth from './index';
 
 class AppProvider extends React.Component {
     state = {
         user: {}
-    };
+	};
 
     render() {
         return (
@@ -12,7 +13,7 @@ class AppProvider extends React.Component {
                 value={{
                     user: this.state.user,
                     setUser: user => {
-                        debugger;
+                        // debugger;
                         const stateUser = Object.assign({}, this.state.user);
                         this.setState({
                             user

--- a/src/Components/Login/Login.js
+++ b/src/Components/Login/Login.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import { Redirect } from 'react-router-dom';
 import AppContext from '../../AppContext';
+import {fakeAuth} from '../../index';
 
 export default class Login extends Component {
     constructor(props){
@@ -12,10 +13,9 @@ export default class Login extends Component {
     }
 
     login(event, context){
-        debugger;
         const user = { Name: 'Test User'}
         context.setUser(user);
-        //alert('about to log in');
+        alert('about to log in');
         this.setState({redirectToReferrer:true});
     }
 
@@ -29,15 +29,17 @@ export default class Login extends Component {
         } = this.props.location.state || { from: { pathname: '/'}};
         
         if(redirectToReferrer){
+			fakeAuth.authenticate();
+			console.log(from);
             return (
-                <Redirect to={from} />
+                <Redirect to={from.pathname} />
             )
         }
 
         return (
             <AppContext.Consumer>
                 {context => (
-                    <div>
+					<div>
                         <div>You must log in to view {from.pathname}</div>
                         <button onClick={(e) => this.login(e, context)}>LOGIN</button>
                     </div>

--- a/src/index.js
+++ b/src/index.js
@@ -14,8 +14,9 @@ import AuthContent2 from './Components/AuthContent2/AuthContent2';
 import OpenContent1 from './Components/OpenContent1/OpenContent1';
 import OpenContent2 from './Components/OpenContent2/OpenContent2';
 import Login from './Components/Login/Login';
+import AppProvider from './AppProvider';
 
-const fakeAuth = {
+export const fakeAuth = {
     isAuthenticated: false,
     authenticate(cb){
         this.isAuthenticated = true;
@@ -40,6 +41,7 @@ const PrivateRoute = ({component: Component, ...rest}) => (
 
 const routing = (
     <Router>
+		<AppProvider>
       <div>
         <Route exact path="/" component={App} />
         <Route path="/Login" component={Login} />
@@ -48,6 +50,7 @@ const routing = (
         <Route path="/OpenContent1" component={OpenContent1} />
         <Route path="/OpenContent2" component={OpenContent2} />
       </div>
+	  </AppProvider>
     </Router>
   )
 


### PR DESCRIPTION
error:
login class was unable to access context.setUser due to not being properly wrapped in <AppContext.Provider>.
fix:
Provider moved to index.js to wrap the entire app.

error:
routing did not occur after login due to fakeAuth.authenticate not being called.
fix:
fakeauth imported into login.js and called upon redirection.